### PR TITLE
This commit adds tests for the executor.

### DIFF
--- a/plugin/contrib/mesos/pkg/executor/mock_test.go
+++ b/plugin/contrib/mesos/pkg/executor/mock_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
+	"github.com/mesos/mesos-go/mesosproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockExecutorDriver struct {
+	mock.Mock
+}
+
+func (m *MockExecutorDriver) Start() (mesosproto.Status, error) {
+	args := m.Called()
+	return args.Get(0).(mesosproto.Status), args.Error(1)
+}
+
+func (m *MockExecutorDriver) Stop() (mesosproto.Status, error) {
+	args := m.Called()
+	return args.Get(0).(mesosproto.Status), args.Error(1)
+}
+
+func (m *MockExecutorDriver) Abort() (mesosproto.Status, error) {
+	args := m.Called()
+	return args.Get(0).(mesosproto.Status), args.Error(1)
+}
+
+func (m *MockExecutorDriver) Join() (mesosproto.Status, error) {
+	args := m.Called()
+	return args.Get(0).(mesosproto.Status), args.Error(1)
+}
+
+func (m *MockExecutorDriver) Run() (mesosproto.Status, error) {
+	args := m.Called()
+	return args.Get(0).(mesosproto.Status), args.Error(1)
+}
+
+func (m *MockExecutorDriver) SendStatusUpdate(taskStatus *mesosproto.TaskStatus) (mesosproto.Status, error) {
+	args := m.Called(*taskStatus.State)
+	return args.Get(0).(mesosproto.Status), args.Error(1)
+}
+
+func (m *MockExecutorDriver) SendFrameworkMessage(msg string) (mesosproto.Status, error) {
+	args := m.Called(msg)
+	return args.Get(0).(mesosproto.Status), args.Error(1)
+}
+
+func NewTestKubernetesExecutor() *KubernetesExecutor {
+	return New(Config{
+		Docker:  dockertools.ConnectToDockerOrDie("fake://"),
+		Updates: make(chan interface{}, 1024),
+	})
+}
+
+func TestExecutorNew(t *testing.T) {
+	mockDriver := &MockExecutorDriver{}
+	executor := NewTestKubernetesExecutor()
+	executor.Init(mockDriver)
+
+	assert.Equal(t, executor.isDone(), false, "executor should not be in Done state on initialization")
+	assert.Equal(t, executor.isConnected(), false, "executor should not be connected on initialization")
+}


### PR DESCRIPTION
- Initial scaffolding and some basic tests for the executor
- Add test for Shutdown.
- Add some tests for LaunchTask, KillTask, FrameworkMessage.
- General code cleanup.
- Improve FrameworkMessage test.
- Fix argument ordering of calls to assert.Equal.
- Fix double-close issue that results from abstracting our call to Exit.
- Add test for sendFrameworkMessage, remove broken code.
- Beginnings of scaffolding to eventually hit the *launchTask methods
- Clean up unused functionality.
- Test the *launchTask functions.
- Update ExitFunc signature.
- Address @jdef's feedback.
- Add Source to PodUpdate.
