### PR TITLE
Add static pod support to mesos scheduler and executor

### DIFF
--- a/plugin/contrib/mesos/pkg/archive/zip.go
+++ b/plugin/contrib/mesos/pkg/archive/zip.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package archive
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+// ZipWalker returns a filepath.WalkFunc that adds every filesystem node
+// to the given *zip.Writer.
+func ZipWalker(zw *zip.Writer) filepath.WalkFunc {
+	var base string
+	return func(path string, info os.FileInfo, err error) error {
+		if base == "" {
+			base = path
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+
+		if header.Name, err = filepath.Rel(base, path); err != nil {
+			return err
+		} else if info.IsDir() {
+			header.Name = header.Name + string(filepath.Separator)
+		} else {
+			header.Method = zip.Deflate
+		}
+
+		w, err := zw.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(w, f)
+		f.Close()
+		return err
+	}
+}
+
+// Create a zip of all files in a directory recursively, return a byte array and
+// the number of files archived.
+func ZipDir(path string) ([]byte, int, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	zipWalker := ZipWalker(zw)
+	numberManifests := 0
+	err := filepath.Walk(path, filepath.WalkFunc(func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			numberManifests++
+		}
+		return zipWalker(path, info, err)
+	}))
+
+	if err != nil {
+		return nil, 0, err
+	} else if err = zw.Close(); err != nil {
+		return nil, 0, err
+	}
+	return buf.Bytes(), numberManifests, nil
+}
+
+// UnzipDir unzips all files from a given zip byte array into a given directory.
+// The directory is created if it does not exist yet.
+func UnzipDir(data []byte, destPath string) error {
+	// open zip
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return fmt.Errorf("Unzip archive read error: %v", err)
+	}
+
+	for _, file := range zr.File {
+		// skip directories
+		if file.FileInfo().IsDir() {
+			continue
+		}
+
+		// open file
+		rc, err := file.Open()
+		defer rc.Close()
+		if err != nil {
+			return fmt.Errorf("Unzip file read error: %v", err)
+		}
+
+		// make sure the directory of the file exists, otherwise create
+		destPath := filepath.Clean(filepath.Join(destPath, file.Name))
+		destBasedir := path.Dir(destPath)
+		err = os.MkdirAll(destBasedir, 0755)
+		if err != nil {
+			return fmt.Errorf("Unzip mkdir error: %v", err)
+		}
+
+		// create file
+		f, err := os.Create(destPath)
+		if err != nil {
+			return fmt.Errorf("Unzip file creation error: %v", err)
+		}
+		defer f.Close()
+
+		// write file
+		if _, err := io.Copy(f, rc); err != nil {
+			return fmt.Errorf("Unzip file write error: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/plugin/contrib/mesos/pkg/archive/zip_test.go
+++ b/plugin/contrib/mesos/pkg/archive/zip_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package archive
+
+import (
+	"archive/zip"
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestZipWalker(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tree := map[string]string{"a/b/c": "12345", "a/b/d": "54321", "a/e": "00000"}
+	for path, content := range tree {
+		path = filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(path), os.ModeTemporary|0700); err != nil {
+			t.Fatal(err)
+		} else if err = ioutil.WriteFile(path, []byte(content), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	if err := filepath.Walk(dir, ZipWalker(zw)); err != nil {
+		t.Fatal(err)
+	} else if err = zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, file := range zr.File {
+		if rc, err := file.Open(); err != nil {
+			t.Fatal(err)
+		} else if got, err := ioutil.ReadAll(rc); err != nil {
+			t.Error(err)
+		} else if want := []byte(tree[file.Name]); !bytes.Equal(got, want) {
+			t.Errorf("%s\ngot:  %s\nwant: %s", file.Name, got, want)
+		}
+	}
+}

--- a/plugin/contrib/mesos/pkg/executor/executor_test.go
+++ b/plugin/contrib/mesos/pkg/executor/executor_test.go
@@ -17,9 +17,13 @@ limitations under the License.
 package executor
 
 import (
+	"archive/zip"
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -31,6 +35,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/client/cache"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet"
+	kconfig "github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/config"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/kubelet/dockertools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/runtime"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -41,6 +46,7 @@ import (
 	"github.com/golang/glog"
 	bindings "github.com/mesos/mesos-go/executor"
 	"github.com/mesos/mesos-go/mesosproto"
+	"github.com/mesos/mesos-go/mesosutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -394,6 +400,144 @@ func TestExecutorLaunchAndKillTask(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timed out waiting for status update calls to finish")
 	}
+	mockDriver.AssertExpectations(t)
+}
+
+// TestExecutorStaticPods test that the ExecutorInfo.data is parsed
+// as a zip archive with pod definitions.
+func TestExecutorStaticPods(t *testing.T) {
+	// create some zip with static pod definition
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	createStaticPodFile := func(fileName, id, name string) {
+		w, err := zw.Create(fileName)
+		assert.NoError(t, err)
+		spod := `{
+	  "kind": "Pod",
+	  "apiVersion": "v1beta1",
+	  "id": "%v",
+	  "desiredState": {
+		"manifest": {
+		  "version": "v1beta1",
+		  "containers": [{
+			"name": "%v",
+			"image": "library/nginx",
+			"ports": [{
+			  "containerPort": 80,
+			  "name": "http"
+			}],
+			"livenessProbe": {
+			  "enabled": true,
+			  "type": "http",
+			  "initialDelaySeconds": 30,
+			  "httpGet": {
+				"path": "/",
+				"port": "80"
+			  }
+			}
+		  }]
+		}
+	  },
+	  "labels": {
+		"name": "foo",
+		"cluster": "gce"
+	  }
+	}`
+		_, err = w.Write([]byte(fmt.Sprintf(spod, id, name)))
+		assert.NoError(t, err)
+	}
+	createStaticPodFile("spod.json", "spod-id-01", "spod-01")
+	createStaticPodFile("spod2.json", "spod-id-02", "spod-02")
+	createStaticPodFile("dir/spod.json", "spod-id-03", "spod-03") // same file name as first one to check for overwriting
+
+	expectedStaticPodsNum := 2 // subdirectories are ignored by FileSource, hence only 2
+
+	err := zw.Close()
+	assert.NoError(t, err)
+
+	// create fake apiserver
+	testApiServer := NewTestServer(t, api.NamespaceDefault, nil)
+	defer testApiServer.server.Close()
+
+	// temporary directory which is normally located in the executor sandbox
+	staticPodsConfigPath, err := ioutil.TempDir("/tmp", "executor-k8sm-archive")
+	assert.NoError(t, err)
+	defer os.RemoveAll(staticPodsConfigPath)
+
+	mockDriver := &MockExecutorDriver{}
+	updates := make(chan interface{}, 1024)
+	config := Config{
+		Docker:  dockertools.ConnectToDockerOrDie("fake://"),
+		Updates: make(chan interface{}, 1), // allow kube-executor source to proceed past init
+		APIClient: client.NewOrDie(&client.Config{
+			Host:    testApiServer.server.URL,
+			Version: testapi.Version(),
+		}),
+		Kubelet: &kubelet.Kubelet{},
+		PodStatusFunc: func(kl *kubelet.Kubelet, pod *api.Pod) (api.PodStatus, error) {
+			return api.PodStatus{
+				ContainerStatuses: []api.ContainerStatus{
+					{
+						Name: "foo",
+						State: api.ContainerState{
+							Running: &api.ContainerStateRunning{},
+						},
+					},
+				},
+				Phase: api.PodRunning,
+			}, nil
+		},
+		StaticPodsConfigPath: staticPodsConfigPath,
+	}
+	executor := New(config)
+	hostname := "h1"
+	go executor.InitializeStaticPodsSource(func() {
+		kconfig.NewSourceFile(staticPodsConfigPath, hostname, 1*time.Second, updates)
+	})
+
+	// create ExecutorInfo with static pod zip in data field
+	executorInfo := mesosutil.NewExecutorInfo(
+		mesosutil.NewExecutorID("ex1"),
+		mesosutil.NewCommandInfo("k8sm-executor"),
+	)
+	executorInfo.Data = buf.Bytes()
+
+	// start the executor with the static pod data
+	executor.Init(mockDriver)
+	executor.Registered(mockDriver, executorInfo, nil, nil)
+
+	// wait for static pod to start
+	seenPods := map[string]struct{}{}
+	done := make(chan struct{})
+	go func() {
+		for {
+			// filter by PodUpdate type
+			select {
+			case update, ok := <-updates:
+				if !ok {
+					return
+				}
+				switch update.(type) {
+				case kubelet.PodUpdate:
+					// register the seen pods by name
+					podUpdate := update.(kubelet.PodUpdate)
+					for _, pod := range podUpdate.Pods {
+						seenPods[pod.Name] = struct{}{}
+					}
+					if len(seenPods) == expectedStaticPodsNum {
+						close(done)
+					}
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("Executor should send pod updates for %v pods, only saw %v", expectedStaticPodsNum, len(seenPods))
+	}
+
 	mockDriver.AssertExpectations(t)
 }
 

--- a/plugin/contrib/mesos/pkg/scheduler/plugin_test.go
+++ b/plugin/contrib/mesos/pkg/scheduler/plugin_test.go
@@ -414,12 +414,16 @@ func TestPlugin_LifeCycle(t *testing.T) {
 	testApiServer := NewTestServer(t, api.NamespaceDefault, &podListWatch.list)
 	defer testApiServer.server.Close()
 
+	// create executor with some data for static pods if set
+	executor := util.NewExecutorInfo(
+		util.NewExecutorID("executor-id"),
+		util.NewCommandInfo("executor-cmd"),
+	)
+	executor.Data = []byte{0, 1, 2}
+
 	// create scheduler
 	testScheduler := New(Config{
-		Executor: util.NewExecutorInfo(
-			util.NewExecutorID("executor-id"),
-			util.NewCommandInfo("executor-cmd"),
-		),
+		Executor:     executor,
 		Client:       client.NewOrDie(&client.Config{Host: testApiServer.server.URL, Version: testapi.Version()}),
 		ScheduleFunc: FCFSScheduleFunc,
 		Schedcfg:     *schedcfg.CreateDefaultConfig(),
@@ -510,6 +514,9 @@ func TestPlugin_LifeCycle(t *testing.T) {
 	assert.EventWithReason(eventObserver, "scheduled")
 	mockDriver.AssertNumberOfCalls(t, "LaunchTasks", 1)
 	assert.Equal(1, len(launchTasks_taskInfos))
+
+	// check that ExecutorInfo.data has the static pod data
+	assert.Len(launchTasks_taskInfos[0].Executor.Data, 3)
 
 	// report back that the task has been staged by mesos
 	launchedTask := launchTasks_taskInfos[0]

--- a/plugin/contrib/mesos/pkg/scheduler/podtask/pod_task.go
+++ b/plugin/contrib/mesos/pkg/scheduler/podtask/pod_task.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	containerCpus = 0.25 // initial CPU allocated for executor
-	containerMem  = 64   // initial MB of memory allocated for executor
+	DefaultContainerCpus = 0.25 // initial CPU allocated for executor
+	DefaultContainerMem = 64   // initial MB of memory allocated for executor
 )
 
 type StateType int
@@ -163,8 +163,8 @@ func (t *T) FillFromDetails(details *mesos.Offer) error {
 
 	t.Spec = Spec{
 		SlaveID: details.GetSlaveId().GetValue(),
-		CPU:     containerCpus,
-		Memory:  containerMem,
+		CPU:     DefaultContainerCpus,
+		Memory:  DefaultContainerMem,
 	}
 
 	if mapping, err := t.mapper.Generate(t, details); err != nil {
@@ -229,7 +229,7 @@ func (t *T) AcceptOffer(offer *mesos.Offer) bool {
 		log.V(3).Info(err)
 		return false
 	}
-	if (cpus < containerCpus) || (mem < containerMem) {
+	if (cpus < DefaultContainerCpus) || (mem < DefaultContainerMem) {
 		log.V(3).Infof("not enough resources: cpus: %f mem: %f", cpus, mem)
 		return false
 	}

--- a/plugin/contrib/mesos/pkg/scheduler/service/service.go
+++ b/plugin/contrib/mesos/pkg/scheduler/service/service.go
@@ -36,6 +36,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/master/ports"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/tools"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/contrib/mesos/pkg/archive"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/contrib/mesos/pkg/election"
 	execcfg "github.com/GoogleCloudPlatform/kubernetes/plugin/contrib/mesos/pkg/executor/config"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/contrib/mesos/pkg/hyperkube"
@@ -46,6 +47,7 @@ import (
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/contrib/mesos/pkg/scheduler/ha"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/contrib/mesos/pkg/scheduler/meta"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/contrib/mesos/pkg/scheduler/metrics"
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/contrib/mesos/pkg/scheduler/podtask"
 	"github.com/GoogleCloudPlatform/kubernetes/plugin/contrib/mesos/pkg/scheduler/uid"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/gogo/protobuf/proto"
@@ -116,6 +118,7 @@ type SchedulerServer struct {
 	KubeletHostNetworkSources     string
 	KubeletSyncFrequency          time.Duration
 	KubeletNetworkPluginName      string
+	StaticPodsConfigPath          string
 
 	executable  string // path to the binary running this service
 	client      *client.Client
@@ -174,6 +177,7 @@ func (s *SchedulerServer) addCoreFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.AllowPrivileged, "allow-privileged", s.AllowPrivileged, "If true, allow privileged containers.")
 	fs.StringVar(&s.ClusterDomain, "cluster-domain", s.ClusterDomain, "Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains")
 	fs.Var(&s.ClusterDNS, "cluster-dns", "IP address for a cluster DNS server. If set, kubelet will configure all containers to use this for DNS resolution in addition to the host's DNS servers")
+	fs.StringVar(&s.StaticPodsConfigPath, "static-pods-config", s.StaticPodsConfigPath, "Path for specification of static pods. Path should point to dir containing the staticPods configuration files. Defaults to none.")
 
 	fs.StringVar(&s.MesosMaster, "mesos-master", s.MesosMaster, "Location of the Mesos master. The format is a comma-delimited list of of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard URLs like http://localhost are also acceptable.")
 	fs.StringVar(&s.MesosUser, "mesos-user", s.MesosUser, "Mesos user for this framework, defaults to root.")
@@ -351,6 +355,25 @@ func (s *SchedulerServer) prepareExecutorInfo(hks hyperkube.Interface) (*mesos.E
 		Command: ci,
 		Name:    proto.String(execcfg.DefaultInfoName),
 		Source:  proto.String(execcfg.DefaultInfoSource),
+	}
+
+	// Check for staticPods
+	if s.StaticPodsConfigPath != "" {
+		bs, numberStaticPods, err := archive.ZipDir(s.StaticPodsConfigPath)
+		if err != nil {
+			return nil, nil, err
+		}
+		info.Data = bs
+
+		// Adjust the resource accounting for the executor.
+		// Currently each podTask accounts the default amount of resources.
+		// TODO(joerg84) adapt to actual resources specified by pods.
+		log.Infof("Detected %d staticPods in Configuration.", numberStaticPods)
+
+		info.Resources = []*mesos.Resource{
+			mutil.NewScalarResource("cpus", float64(numberStaticPods)*podtask.DefaultContainerCpus),
+			mutil.NewScalarResource("mem", float64(numberStaticPods)*podtask.DefaultContainerMem),
+		}
 	}
 
 	// calculate ExecutorInfo hash to be used for validating compatibility

--- a/plugin/contrib/mesos/pkg/scheduler/service/service_test.go
+++ b/plugin/contrib/mesos/pkg/scheduler/service/service_test.go
@@ -19,8 +19,16 @@ limitations under the License.
 package service
 
 import (
+	"archive/zip"
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/GoogleCloudPlatform/kubernetes/plugin/contrib/mesos/pkg/archive"
+	"github.com/stretchr/testify/assert"
 )
 
 type fakeSchedulerProcess struct {
@@ -105,4 +113,43 @@ func Test_awaitFailoverDoneFailover(t *testing.T) {
 	if !failoverHandlerCalled {
 		t.Fatalf("expected call to failover handler")
 	}
+}
+
+func Test_StaticPods(t *testing.T) {
+	assert := assert.New(t)
+
+	// create static pods config files, spod1 on toplevel and spod2 in a directory "dir"
+	staticPodsConfigPath, err := ioutil.TempDir(os.TempDir(), "executor-k8sm-archive")
+	assert.NoError(err)
+	defer os.RemoveAll(staticPodsConfigPath)
+
+	spod1, err := os.Create(filepath.Join(staticPodsConfigPath, "spod1.json"))
+	assert.NoError(err)
+	_, err = spod1.WriteString("content1")
+	assert.NoError(err)
+
+	err = os.Mkdir(filepath.Join(staticPodsConfigPath, "dir"), 0755)
+	assert.NoError(err)
+
+	spod2, err := os.Create(filepath.Join(staticPodsConfigPath, "dir", "spod2.json"))
+	assert.NoError(err)
+	_, err = spod2.WriteString("content2")
+	assert.NoError(err)
+
+	// archive config files
+	data, fileNum, err := archive.ZipDir(staticPodsConfigPath)
+	assert.NoError(err)
+	assert.Equal(2, fileNum)
+
+	// unarchive config files
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	assert.NoError(err)
+	fileNames := []string{}
+	for _, f := range zr.File {
+		if !f.FileInfo().IsDir() {
+			fileNames = append(fileNames, f.Name)
+		}
+	}
+	assert.Contains(fileNames, "spod1.json")
+	assert.Contains(fileNames, "dir/spod2.json")
 }


### PR DESCRIPTION
- the mesos scheduler gets a --static-pods-config parameter with a directory with
  pods specs. They are zipped and sent over to newly started mesos executors.
- the mesos executor receives the zipper static pod config via ExecutorInfo.Data
  and starts up the pods via the kubelet FileSource mechanism.
- both - the scheduler and the executor side - are fully unit tested
