### PR TITLE
EXPERIMENTAL: Poll apiserver for new pods from executor

### DIFF
--- a/contrib/mesos/pkg/executor/messages/messages.go
+++ b/contrib/mesos/pkg/executor/messages/messages.go
@@ -20,6 +20,7 @@ package messages
 
 const (
 	ContainersDisappeared    = "containers-disappeared"
+	ContainersFinished       = "containers-finished"
 	CreateBindingFailure     = "create-binding-failure"
 	CreateBindingSuccess     = "create-binding-success"
 	ExecutorUnregistered     = "executor-unregistered"


### PR DESCRIPTION
Probably we should use a ListWatch instead of polling. But in general the idea of getting rid of the deep call into the kubelet to get the pod status works. kube-dns and kube-ui come up and their status is updated (by kubelet's status manager).
