### PR TITLE
Make framework SlaveRegistry aware of per-host executor ids

### DIFF
--- a/contrib/mesos/pkg/scheduler/integration/integration_test.go
+++ b/contrib/mesos/pkg/scheduler/integration/integration_test.go
@@ -473,7 +473,6 @@ func newLifecycleTest(t *testing.T) lifecycleTest {
 	})
 	c := *schedcfg.CreateDefaultConfig()
 	fw := framework.New(framework.Config{
-		Executor:        ei,
 		Client:          client,
 		SchedulerConfig: c,
 		LookupNode:      apiServer.LookupNode,

--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -706,7 +706,6 @@ func (s *SchedulerServer) bootstrap(hks hyperkube.Interface, sc *schedcfg.Config
 
 	framework := framework.New(framework.Config{
 		SchedulerConfig:   *sc,
-		Executor:          eiPrototype,
 		Client:            client,
 		FailoverTimeout:   s.failoverTimeout,
 		ReconcileInterval: s.reconcileInterval,


### PR DESCRIPTION
For each slave the executor id is stored. This is necessary to send framework
messages, e.g. for the kamikaze endpoint. For this we start without the executor
id when an offer comes in. With incoming TASK_STATUS messages we add the
executor id to the registry. When an executor is lost, we remove it again.
